### PR TITLE
add JS error tracking to google analytics

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -78,6 +78,27 @@
 
         ga('create', 'UA-50407686-1', 'auto');
         </script>
+        <script>
+        trackJsError = function(e) {
+          var ie = window.event,
+              errMsg = e.message || ie.errorMessage;
+          var errSrc = (e.filename || ie.errorUrl) + ': ' + (e.lineno || ie.errorLine);
+          ga('send', 'exception', {
+              'exDescription': errSrc + ': ' + errMsg,
+              'exFatal': false
+          });
+        }
+        /**
+         * Cross-browser event listener
+         */
+        if (window.addEventListener) {
+          window.addEventListener('error', trackJsError, false);
+        } else if (window.attachEvent) {
+          window.attachEvent('onerror', trackJavaScriptError);
+        } else {
+          window.onerror = trackJavaScriptError;
+        }
+        </script>
     <% } else { %>
         <script data-main="/scripts/main.js" src="/scripts/libs/require.js"></script>
     <% } %>


### PR DESCRIPTION
we need to get more insight into what is happening on the client side, this will help us get some visibility into what type of errors clients are facing, hopefully it wont just be trash that we can't filter out.
