### PR TITLE
make sure map width is always 100% on live map

### DIFF
--- a/src/scripts/directives/liveMap.coffee
+++ b/src/scripts/directives/liveMap.coffee
@@ -3,27 +3,28 @@ angular.module('app').directive 'liveMap', ['$window', ($window) -> return {
   transclude: true
   controller: 'liveMapController'
   templateUrl: '/views/directives/live-map.html'
-  compile: (element, attributes) ->
-    pre: ($scope, element, attrs) ->
-      sameRouteSameParams = (config) -> $scope.urlBase == config.url
+  link: ($scope, $element, attrs) ->
+    sameRouteSameParams = (config) -> $scope.urlBase == config.url
 
-      $scope.$on 'loading-started', (event, config) ->
-        $scope.recordsLoaded(false, config) if sameRouteSameParams(config)
-      $scope.$on 'loading-complete', (event, config) ->
-        $scope.recordsLoaded(true, config) if sameRouteSameParams(config)
+    $scope.$on 'loading-started', (event, config) ->
+      $scope.recordsLoaded(false, config) if sameRouteSameParams(config)
+    $scope.$on 'loading-complete', (event, config) ->
+      $scope.recordsLoaded(true, config) if sameRouteSameParams(config)
 
-      $scope.ui_bounds = $('#main-navigation').height() + $('#footer').height()
-      $scope.initializeWindowSize = ->
-        $scope.windowHeight = $window.innerHeight - ( $scope.ui_bounds )
-        $scope.windowWidth = $window.innerWidth
+    $scope.uiBounds = $('#main-navigation').height() + $('#footer').height()
+    $scope.initializeWindowSize = ->
+      $scope.windowHeight = $window.innerHeight - ( $scope.uiBounds )
 
-        $scope.leafletData.getMap().then (map) ->
-          $(map._container).css
-            height: "#{$scope.windowHeight}px"
-            width: "#{$scope.windowWidth}px"
-          map.invalidateSize(false)
-      angular.element($window).bind 'resize', ->
-        $scope.initializeWindowSize()
-        $scope.$apply()
+      $scope.leafletData.getMap().then (map) ->
+        $(map._container).css
+          height: "#{$scope.windowHeight}px"
+          width: "100%"
+        map.invalidateSize(false)
+
+    angular.element($window).bind 'resize', ->
       $scope.initializeWindowSize()
+      $scope.$apply()
+
+    # apply window resize on initialize
+    $scope.initializeWindowSize()
 }]


### PR DESCRIPTION
Previously live map directive was resizing the map to the window innerWidth but on some cases that includes the horizontal scrollbar width causing the map to be larger than it should and creating a new vertical scrollbar.

This wasn't detected since I was using OS X with the fancy non scrollbar sliders that autohide.

![screenshot 2014-09-17 16 20 48](https://cloud.githubusercontent.com/assets/317648/4312994/78f34dec-3ec1-11e4-80e3-5887a858948c.png)

fixes #28 

![screenshot 2014-09-17 16 18 55](https://cloud.githubusercontent.com/assets/317648/4312967/0cad7e82-3ec1-11e4-82af-2bdd01de6086.png)
