### PR TITLE
This file must be in source control to nicely use sublime.

### DIFF
--- a/megadroneshare.sublime-project
+++ b/megadroneshare.sublime-project
@@ -1,0 +1,9 @@
+{
+	"folders":
+	[
+		{
+			"follow_symlinks": true,
+			"path": "src"
+		}
+	]
+}


### PR DESCRIPTION
If we could keep this file in src control it would make life easier for sublime users

> As a general rule, the sublime-project file would be checked into version control, while the sublime-workspace file would not.
